### PR TITLE
chore(test): add validation on user IDs

### DIFF
--- a/internal/provider/resource_lakekeeper_user.go
+++ b/internal/provider/resource_lakekeeper_user.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/baptistegh/terraform-provider-lakekeeper/lakekeeper"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -49,6 +51,12 @@ func (r *lakekeeperUserResource) Schema(ctx context.Context, req resource.Schema
 			"id": schema.StringAttribute{
 				MarkdownDescription: `The ID of the user. The id must be identical to the subject in JWT tokens, prefixed with` + "`<idp-identifier>~`" + `. For example: ` + "`oidc~1234567890`" + ` for OIDC users or kubernetes~1234567890 for Kubernetes users.`,
 				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(fmt.Sprintf("^(%s).+$", strings.Join(lakekeeper.ValidUserIDPPrefixes, "|"))),
+						"The id must be prefixed with `<idp-identifier>~`. `<idp-identifier>` can be `oidc` or `kubernetes`.",
+					),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "The name of the user.",

--- a/lakekeeper/user.go
+++ b/lakekeeper/user.go
@@ -25,7 +25,10 @@ type UserCreateRequest struct {
 	UpdateIfExists bool   `json:"update-if-exists"`
 }
 
-var ValidUserTypes = []string{"human", "application"}
+var (
+	ValidUserTypes       = []string{"human", "application"}
+	ValidUserIDPPrefixes = []string{"oidc", "kubernetes"}
+)
 
 func (client *Client) Whoami(ctx context.Context) (*User, error) {
 	var user User


### PR DESCRIPTION
Just to be sure a user ID can't be provided without its prefix:

- `oidc~`
- `kubernetes~`