### PR TITLE
ci: fix dependabot on docker compose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
           - "*" # Group all GitHub Actions dependencies together
     schedule:
       interval: "daily"
-  - package-ecosystem: "docker"
+  - package-ecosystem: "docker-compose"
     directory: "/run"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Dependabot was failing on Docker compose image updates. 
Wrong package ecosystem: ~~docker~~ docker-compose