### PR TITLE
feat: allow setting warehouse parameters as unknown variables

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
-          terraform_version: 1.12.2
+          terraform_version: 1.9.8
           terraform_wrapper: false
       - run: go mod download
       - name: Starting Lakekeeper instance (and third parties)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
+          terraform_version: 1.9.8
       - name: Run Terraform linter on examples and playground
         run: terraform fmt -recursive -check -diff ./examples ./playground
       - name: Install shfmt cli

--- a/README.md
+++ b/README.md
@@ -1,30 +1,31 @@
-<div align="center">
-    <h1>Terraform Provider Lakekeeper</h1>
-    <p>
-Terraform provider for <a href="https://docs.lakekeeper.io/">Lakekeeper</a>.<p>
-    <a href="https://registry.terraform.io/providers/baptistegh/lakekeeper/latest/docs"><img src="https://img.shields.io/static/v1?label=Docs&message=terraform-provider-lakekeeper&color=000000&style=for-the-badge" /></a>
-  <a href="https://github.com/baptistegh/terraform-provider-lakekeeper/releases"><img src="https://img.shields.io/badge/status-preview-orange?style=for-the-badge" /></a>
-</div>
+# Terraform Provider for Lakekeeper
+
+[![docs](https://img.shields.io/static/v1?label=Docs&message=terraform-provider-lakekeeper&color=5c4ee5)](https://registry.terraform.io/providers/baptistegh/lakekeeper/latest/docs])
+[![docs](https://img.shields.io/badge/status-preview-orange)](https://github.com/baptistegh/terraform-provider-lakekeeper/releases)
+[![Nightly Acceptance Tests](https://github.com/baptistegh/terraform-provider-lakekeeper/actions/workflows/nightly.yml/badge.svg)](https://github.com/baptistegh/terraform-provider-lakekeeper/actions/workflows/nightly.yml)
+[![Tests](https://github.com/baptistegh/terraform-provider-lakekeeper/actions/workflows/test.yml/badge.svg)](https://github.com/baptistegh/terraform-provider-lakekeeper/actions/workflows/test.yml)
+
+Terraform provider for [Lakekeeper](https://docs.lakekeeper.io/).
 
 > [!IMPORTANT]  
 > **⚠️ Preview Status Notice**
-> 
+>
 > - ⚠️ **Breaking changes** may occur without notice  
 > - 🔄 APIs and behavior may change significantly between versions  
 > - 🧪 Use at your own risk for development and testing purposes only
-> 
+>
 > **🚧 This project is currently in _preview_ and under active development. It is _not production-ready_ and should not be used in production environments.**
-> 
+>
 > 💬 We welcome [feedback, bug reports, and contributions](https://github.com/baptistegh/terraform-provider-lakekeeper/issues) during this preview phase.
 > Please report issues or share your experience to help us improve the provider before its stable release.
 
 ## Docs
 
-All documentation for this provider can be found on the Terraform Registry: https://registry.terraform.io/providers/baptistegh/lakekeeper/latest/docs.
+All documentation for this provider can be found on the Terraform Registry: <https://registry.terraform.io/providers/baptistegh/lakekeeper/latest/docs>.
 
 ## Installation
 
-This provider can be installed automatically using Terraform >=0.13 by using the `terraform` configuration block:
+This provider can be installed automatically by using the `terraform` configuration block:
 
 ```terraform
 terraform {
@@ -48,7 +49,7 @@ The following Lakekeeper versions are used when running acceptance tests in CI:
 _The provider should be compatible with Lakekeeper >= v0.9.3 thanks to the introduction of skip storage validation._
 _See: [lakekeeper/lakekeeper#1239](https://github.com/lakekeeper/lakekeeper/pull/1239)_
 
-_Acceptance tests are executed using Terraform v1.12.2._
+_Acceptance tests are executed using Terraform v1.9.8._
 
 ## Releases
 
@@ -56,7 +57,7 @@ This provider uses [GoReleaser](https://goreleaser.com/]) to build and publish r
 
 Each release also contains a `terraform-provider-lakekeeper_${RELEASE_VERSION}_SHA256SUMS` file that can be used to check integrity.
 
-You can find the list of releases [here](https://github.com/baptistegh/terraform-provider-lakekeeper/releases). You can find the changelog for each version [here](https://github.com/baptistegh/terraform-provider-lakekeeper/blob/main/CHANGELOG.md).
+You can find the [list of releases](https://github.com/baptistegh/terraform-provider-lakekeeper/releases) and the [changelog](https://github.com/baptistegh/terraform-provider-lakekeeper/blob/main/CHANGELOG.md) for each version.
 
 ## Playground
 
@@ -66,19 +67,19 @@ A sample playground project is available in the `/playground` directory. It is b
 
 This playground will set up the following structure:
 
-* **Warehouse:**
-  * Configured using a `gcs` (Google Cloud Storage) storage profile.
-* **Roles:**
-  * with `select` and `describe` permissions on the warehouse. 
-* **Users:**
-  * **Anna:**
-    * username: `anna`
-    * password: `iceberg`
-    * `project_admin` assignment on the default project
-  * **Peter:**
-    * username: `peter`
-    * password: `iceberg`
-    * assignee to the role
+- **Warehouse:**
+  - Configured using a `gcs` (Google Cloud Storage) storage profile.
+- **Roles:**
+  - with `select` and `describe` permissions on the warehouse.
+- **Users:**
+  - **Anna:**
+    - username: `anna`
+    - password: `iceberg`
+    - `project_admin` assignment on the default project
+  - **Peter:**
+    - username: `peter`
+    - password: `iceberg`
+    - assignee to the role
 
 ### Setup Instructions
 
@@ -97,7 +98,7 @@ make playground-destroy
 
 ### Usage
 
-You can connect to the web interface at http://localhost:8181 using one of the user credentials listed above to explore the configured resources.
+You can connect to the web interface at <http://localhost:8181> using one of the user credentials listed above to explore the configured resources.
 
 Feel free to modify `playground/main.tf` to customize the structure according to your needs.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/baptistegh/terraform-provider-lakekeeper
 
-go 1.24.4
+go 1.24
+
+toolchain go1.24.5
 
 require (
 	github.com/google/uuid v1.6.0

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -113,7 +113,7 @@ func (p *LakekeeperProvider) Configure(ctx context.Context, req provider.Configu
 		resp.Diagnostics.AddAttributeError(
 			path.Root("endpoint"),
 			"Unknown Lakekeeper Base URL",
-			"The provider cannot create the Lakekeeper API client as there is an unknow configuration value for the Lakekeeper Base URL. "+
+			"The provider cannot create the Lakekeeper API client as there is an unknown configuration value for the Lakekeeper Base URL. "+
 				"Either apply the source of the value first, set the token attribute value statically in the configuration, or use the LAKEKEEPER_ENDPOINT environment variable.",
 		)
 	}
@@ -122,7 +122,7 @@ func (p *LakekeeperProvider) Configure(ctx context.Context, req provider.Configu
 		resp.Diagnostics.AddAttributeError(
 			path.Root("auth_url"),
 			"Unknown OIDC authenticate URL",
-			"The provider cannot create the Lakekeeper API client as there is an unknow configuration value for the OIDC authenticate endpoint. "+
+			"The provider cannot create the Lakekeeper API client as there is an unknown configuration value for the OIDC authenticate endpoint. "+
 				"Either apply the source of the value first, set the auth_url attribute value statically in the configuration, or use the LAKEKEEPER_AUTH_URL environment variable.",
 		)
 	}
@@ -131,7 +131,7 @@ func (p *LakekeeperProvider) Configure(ctx context.Context, req provider.Configu
 		resp.Diagnostics.AddAttributeError(
 			path.Root("client_id"),
 			"Unknown OIDC authenticate endpoint",
-			"The provider cannot create the Lakekeeper API client as there is an unknow configuration value for the OIDC authenticate endpoint. "+
+			"The provider cannot create the Lakekeeper API client as there is an unknown configuration value for the OIDC authenticate endpoint. "+
 				"Either apply the source of the value first, set the client_id attribute value statically in the configuration, or use the LAKEKEEPER_CLIENT_ID environment variable.",
 		)
 	}
@@ -140,7 +140,7 @@ func (p *LakekeeperProvider) Configure(ctx context.Context, req provider.Configu
 		resp.Diagnostics.AddAttributeError(
 			path.Root("client_secret"),
 			"Unknown OIDC authenticate endpoint",
-			"The provider cannot create the Lakekeeper API client as there is an unknow configuration value for the OIDC authenticate endpoint. "+
+			"The provider cannot create the Lakekeeper API client as there is an unknown configuration value for the OIDC authenticate endpoint. "+
 				"Either apply the source of the value first, set the client_secret attribute value statically in the configuration, or use the LAKEKEEPER_CLIENT_SECRET environment variable.",
 		)
 	}
@@ -149,7 +149,7 @@ func (p *LakekeeperProvider) Configure(ctx context.Context, req provider.Configu
 		resp.Diagnostics.AddAttributeError(
 			path.Root("scope"),
 			"Unknown OIDC authenticate endpoint",
-			"The provider cannot create the Lakekeeper API client as there is an unknow configuration value for the OIDC authenticate endpoint. "+
+			"The provider cannot create the Lakekeeper API client as there is an unknown configuration value for the OIDC authenticate endpoint. "+
 				"Either apply the source of the value first, set the scope attribute value statically in the configuration.",
 		)
 	}
@@ -168,46 +168,41 @@ func (p *LakekeeperProvider) Configure(ctx context.Context, req provider.Configu
 			ClientSecret: os.Getenv("LAKEKEEPER_CLIENT_SECRET"),
 			Scopes:       []string{"lakekeeper"},
 		},
-		CACertFile:       "",
-		Insecure:         false,
 		InitialBootstrap: true,
-		EarlyAuthFail:    true,
 	}
 
-	if !config.Endpoint.IsNull() {
+	if !config.Endpoint.IsNull() && !config.Endpoint.IsUnknown() {
 		evaluatedConfig.BaseURL = config.Endpoint.ValueString()
 	}
 
-	if !config.AuthURL.IsNull() {
+	if !config.AuthURL.IsNull() && !config.AuthURL.IsUnknown() {
 		evaluatedConfig.AuthURL = config.AuthURL.ValueString()
 	}
 
-	if !config.ClientID.IsNull() {
+	if !config.ClientID.IsNull() && !config.ClientID.IsUnknown() {
 		evaluatedConfig.ClientID = config.ClientID.ValueString()
 	}
 
-	if !config.ClientSecret.IsNull() {
+	if !config.ClientSecret.IsNull() && !config.ClientSecret.IsUnknown() {
 		evaluatedConfig.ClientSecret = config.ClientSecret.ValueString()
 	}
 
-	if !config.Scopes.IsNull() {
-		for _, elem := range config.Scopes.Elements() {
-			strVal, ok := elem.(types.String)
-			if ok && !strVal.IsNull() && !strVal.IsUnknown() {
-				evaluatedConfig.Scopes = append(evaluatedConfig.Scopes, strVal.ValueString())
-			}
+	if !config.Scopes.IsNull() && !config.Scopes.IsUnknown() {
+		resp.Diagnostics.Append(config.Scopes.ElementsAs(ctx, &config.Scopes, false)...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
 	}
 
-	if !config.CACertFile.IsNull() {
+	if !config.CACertFile.IsNull() && !config.CACertFile.IsUnknown() {
 		evaluatedConfig.CACertFile = config.CACertFile.ValueString()
 	}
 
-	if !config.Insecure.IsNull() {
+	if !config.Insecure.IsNull() && !config.Insecure.IsUnknown() {
 		evaluatedConfig.Insecure = config.Insecure.ValueBool()
 	}
 
-	if !config.InitialBootstrap.IsNull() {
+	if !config.InitialBootstrap.IsNull() && !config.InitialBootstrap.IsUnknown() {
 		evaluatedConfig.InitialBootstrap = config.InitialBootstrap.ValueBool()
 	}
 

--- a/internal/provider/testutil/helpers.go
+++ b/internal/provider/testutil/helpers.go
@@ -15,7 +15,7 @@ import (
 	managementv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1"
 	"github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/storage/credential"
 	"github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/storage/profile"
-	lakekeeper "github.com/baptistegh/go-lakekeeper/pkg/client"
+	"github.com/baptistegh/go-lakekeeper/pkg/client"
 	"github.com/baptistegh/go-lakekeeper/pkg/core"
 )
 
@@ -28,10 +28,9 @@ var testLakekeeperConfig = api.Config{
 		Scopes:       []string{"lakekeeper"},
 	},
 	InitialBootstrap: true,
-	EarlyAuthFail:    true,
 }
 
-var TestLakekeeperClient *lakekeeper.Client
+var TestLakekeeperClient *client.Client
 
 var DefaultUserID string
 

--- a/internal/provider/types/delete_profile.go
+++ b/internal/provider/types/delete_profile.go
@@ -102,7 +102,7 @@ func (v deleteProfileValidator) ValidateObject(ctx context.Context, req validato
 
 	switch deleteProfile.Type.ValueString() {
 	case "soft":
-		if deleteProfile.ExpirationSeconds.IsNull() || deleteProfile.ExpirationSeconds.IsUnknown() {
+		if deleteProfile.ExpirationSeconds.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("expiration_seconds"),
 				"'expiration_seconds' required for type 'soft'",
@@ -110,7 +110,7 @@ func (v deleteProfileValidator) ValidateObject(ctx context.Context, req validato
 			)
 		}
 	case deleteProfile.Type.ValueString():
-		if !deleteProfile.ExpirationSeconds.IsNull() && !deleteProfile.ExpirationSeconds.IsUnknown() {
+		if !deleteProfile.ExpirationSeconds.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("expiration_seconds"),
 				"'expiration_seconds' can't be set for type 'hard'",

--- a/internal/provider/types/storage_credential_validator.go
+++ b/internal/provider/types/storage_credential_validator.go
@@ -36,14 +36,14 @@ func (v storageCredentialValidator) ValidateObject(ctx context.Context, req vali
 
 	switch profile.Type.ValueString() {
 	case "s3_access_key":
-		if profile.AccessKeyID.IsNull() || profile.AccessKeyID.IsUnknown() || profile.AccessKeyID.ValueString() == "" {
+		if profile.AccessKeyID.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("access_key_id"),
 				"'access_key_id' required for type 's3_access_key'",
 				"When 'type' is 's3_access_key', you must set the 'access_key_id' attribute.",
 			)
 		}
-		if profile.SecretAccessKey.IsNull() || profile.SecretAccessKey.IsUnknown() || profile.SecretAccessKey.ValueString() == "" {
+		if profile.SecretAccessKey.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("secret_access_key"),
 				"'secret_access_key' required for type 's3_access_key'",
@@ -53,28 +53,28 @@ func (v storageCredentialValidator) ValidateObject(ctx context.Context, req vali
 	case "s3_aws_system_identity":
 		break
 	case "s3_cloudflare_r2":
-		if profile.AccessKeyID.IsNull() || profile.AccessKeyID.IsUnknown() || profile.AccessKeyID.ValueString() == "" {
+		if profile.AccessKeyID.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("access_key_id"),
 				"'access_key_id' required for type 's3_cloudflare_r2'",
 				"When 'type' is 's3_cloudflare_r2', you must set the 'access_key_id' attribute.",
 			)
 		}
-		if profile.SecretAccessKey.IsNull() || profile.SecretAccessKey.IsUnknown() || profile.SecretAccessKey.ValueString() == "" {
+		if profile.SecretAccessKey.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("secret_access_key"),
 				"'secret_access_key' required for type 's3_cloudflare_r2'",
 				"When 'type' is 's3_cloudflare_r2', you must set the 'secret_access_key' attribute.",
 			)
 		}
-		if profile.AccountID.IsNull() || profile.AccountID.IsUnknown() || profile.AccountID.ValueString() == "" {
+		if profile.AccountID.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("account_id"),
 				"'account_id' required for type 's3_cloudflare_r2'",
 				"When 'type' is 's3_cloudflare_r2', you must set the 'account_id' attribute.",
 			)
 		}
-		if profile.Token.IsNull() || profile.Token.IsUnknown() || profile.Token.ValueString() == "" {
+		if profile.Token.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("token"),
 				"'token' required for type 's3_cloudflare_r2'",
@@ -82,21 +82,21 @@ func (v storageCredentialValidator) ValidateObject(ctx context.Context, req vali
 			)
 		}
 	case "az_client_credentials":
-		if profile.ClientID.IsNull() || profile.ClientID.IsUnknown() || profile.ClientID.ValueString() == "" {
+		if profile.ClientID.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("client_id"),
 				"'client_id' required for type 'az_client_credentials'",
 				"When 'type' is 'az_client_credentials', you must set the 'client_id' attribute.",
 			)
 		}
-		if profile.ClientSecret.IsNull() || profile.ClientSecret.IsUnknown() || profile.ClientSecret.ValueString() == "" {
+		if profile.ClientSecret.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("client_secret"),
 				"'client_secret' required for type 'az_client_credentials'",
 				"When 'type' is 'az_client_credentials', you must set the 'client_secret' attribute.",
 			)
 		}
-		if profile.TenantID.IsNull() || profile.TenantID.IsUnknown() || profile.TenantID.ValueString() == "" {
+		if profile.TenantID.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("tenant_id"),
 				"'tenant_id' required for type 'az_client_credentials'",
@@ -104,7 +104,7 @@ func (v storageCredentialValidator) ValidateObject(ctx context.Context, req vali
 			)
 		}
 	case "az_shared_access_key":
-		if profile.AZKey.IsNull() || profile.AZKey.IsUnknown() || profile.AZKey.ValueString() == "" {
+		if profile.AZKey.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("az_key"),
 				"'az_key' required for type 'az_shared_access_key'",

--- a/internal/provider/warehouse_sdk.go
+++ b/internal/provider/warehouse_sdk.go
@@ -14,9 +14,6 @@ import (
 )
 
 func (m *lakekeeperWarehouseResourceModel) ToWarehouseCreateRequest() (*managementv1.CreateWarehouseOptions, error) {
-	if !m.Active.ValueBool() {
-		return nil, fmt.Errorf("could not create a warehouse with inactive status")
-	}
 	req := managementv1.CreateWarehouseOptions{
 		Name: m.Name.ValueString(),
 	}

--- a/playground/main.tf
+++ b/playground/main.tf
@@ -36,6 +36,12 @@ resource "lakekeeper_project_user_assignment" "default_anna" {
   assignments = ["project_admin"]
 }
 
+// To add perter as a Super Admin, uncomment this section
+// resource "lakekeeper_server_user_assignment" "default_peter" {
+//   user_id     = lakekeeper_user.peter.id
+//   assignments = ["operator"]
+// }
+
 resource "lakekeeper_warehouse" "gcs" {
   name       = "test-warehouse"
   project_id = data.lakekeeper_default_project.default.id


### PR DESCRIPTION
This enables more flexible configuration by deferring parameter resolution.

You can set the warehouse configuration as variables computed from the plan (or other resources).

BEGIN_COMMIT_OVERRIDE
feat: allow setting warehouse parameters as unknown variables (#153)
END_COMMIT_OVERRIDE