### PR TITLE
fix: Use PlanModifiers to reduce the amount of unnecessary "(known after apply)" entires in a plan

### DIFF
--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -56,6 +58,9 @@ func (r *lakekeeperProjectResource) Schema(ctx context.Context, req resource.Sch
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The ID the project.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Name of the project.",

--- a/internal/provider/resource_project_role_assignment.go
+++ b/internal/provider/resource_project_role_assignment.go
@@ -61,6 +61,9 @@ func (r *lakekeeperProjectRoleAssignmentResource) Schema(ctx context.Context, re
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The internal ID of this resource. In the form: {{project_id}}/{{role_id}}",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the project.",

--- a/internal/provider/resource_project_user_assignment.go
+++ b/internal/provider/resource_project_user_assignment.go
@@ -61,6 +61,9 @@ func (r *lakekeeperProjectUserAssignmentResource) Schema(ctx context.Context, re
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The internal ID of this resource. In the form: `{{project_id}}/{{user_id}}`",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the project.",

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -60,14 +62,23 @@ func (r *lakekeeperRoleResource) Schema(ctx context.Context, req resource.Schema
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the role. in the form `{{project_id}}/{{role_id}}`",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"role_id": schema.StringAttribute{
 				MarkdownDescription: `The internal ID of the role.`,
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				MarkdownDescription: `The ID of the project the role belongs to.`,
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "The name of the role.",
@@ -80,6 +91,9 @@ func (r *lakekeeperRoleResource) Schema(ctx context.Context, req resource.Schema
 			"created_at": schema.StringAttribute{
 				MarkdownDescription: "When the role has been created.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				MarkdownDescription: "When the role has last been modified.",

--- a/internal/provider/resource_role_role_assignment.go
+++ b/internal/provider/resource_role_role_assignment.go
@@ -61,6 +61,9 @@ func (r *lakekeeperRoleRoleAssignmentResource) Schema(ctx context.Context, req r
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The internal ID of this resource. In the form: <role_id>:<assignee_id>",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"role_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the role.",

--- a/internal/provider/resource_role_user_assignment.go
+++ b/internal/provider/resource_role_user_assignment.go
@@ -61,6 +61,9 @@ func (r *lakekeeperRoleUserAssignmentResource) Schema(ctx context.Context, req r
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The internal ID of this resource. In the form: <role_id>:<user_id>",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"role_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the role.",

--- a/internal/provider/resource_server_role_assignment.go
+++ b/internal/provider/resource_server_role_assignment.go
@@ -59,6 +59,9 @@ func (r *lakekeeperServerRoleAssignmentResource) Schema(ctx context.Context, req
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The internal ID of this resource. Same as `{{role_id}}`",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"role_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the role.",

--- a/internal/provider/resource_server_user_assignment.go
+++ b/internal/provider/resource_server_user_assignment.go
@@ -59,6 +59,9 @@ func (r *lakekeeperServerUserAssignmentResource) Schema(ctx context.Context, req
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The internal ID of this resource. Same as `{{user_id}}`",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"user_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the user.",

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -66,6 +68,9 @@ func (r *lakekeeperUserResource) Schema(ctx context.Context, req resource.Schema
 				MarkdownDescription: "The email of the user.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"user_type": schema.StringAttribute{
 				MarkdownDescription: fmt.Sprintf("The type of the user, must be `%s` or `%s`", managementv1.HumanUserType, managementv1.ApplicationUserType),
@@ -75,6 +80,9 @@ func (r *lakekeeperUserResource) Schema(ctx context.Context, req resource.Schema
 			"created_at": schema.StringAttribute{
 				MarkdownDescription: "When the user has been created.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				MarkdownDescription: "When the user has last been modified.",

--- a/internal/provider/resource_warehouse.go
+++ b/internal/provider/resource_warehouse.go
@@ -20,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -80,10 +82,16 @@ func (r *lakekeeperWarehouseResource) Schema(ctx context.Context, req resource.S
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The internal ID of this resource. In the form: `{{project_id}}/{{warehouse_id}}`",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"warehouse_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the warehouse.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: `Name of the warehouse to create. Must be unique within a project and may not contain "/"`,
@@ -102,18 +110,27 @@ func (r *lakekeeperWarehouseResource) Schema(ctx context.Context, req resource.S
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"active": schema.BoolAttribute{
 				MarkdownDescription: "Whether the warehouse is active. Default is `true`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"managed_access": schema.BoolAttribute{
 				MarkdownDescription: "Whether the managed access is configured on this warehouse. Default is `false`.",
 				Computed:            true,
 				Optional:            true,
 				Default:             booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"delete_profile": sdk.DeleteProfileResourceSchema(),
 			"storage_profile": schema.SingleNestedAttribute{
@@ -147,6 +164,9 @@ func (r *lakekeeperWarehouseResource) Schema(ctx context.Context, req resource.S
 								Optional:            true,
 								Computed:            true,
 								MarkdownDescription: "Allow `s3a://`, `s3n://`, `wasbs://` in locations. This is disabled by default. We do not recommend to use this setting except for migration.",
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"assume_role_arn": schema.StringAttribute{
 								Optional:            true,
@@ -163,6 +183,9 @@ func (r *lakekeeperWarehouseResource) Schema(ctx context.Context, req resource.S
 								Validators: []validator.String{
 									stringvalidator.RegexMatches(regexp.MustCompile("/$"), "Endpoint must ends with '/' character"),
 								},
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"flavor": schema.StringAttribute{
 								Optional: true,
@@ -171,16 +194,25 @@ func (r *lakekeeperWarehouseResource) Schema(ctx context.Context, req resource.S
 									stringvalidator.OneOf(string(profile.S3CompatFlavor), string(profile.AWSFlavor)),
 								},
 								MarkdownDescription: fmt.Sprintf("S3 flavor to use. Defaults to `%s`. One of `%s` `%s`", profile.AWSFlavor, profile.S3CompatFlavor, profile.AWSFlavor),
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"path_style_access": schema.BoolAttribute{
 								Optional:            true,
 								Computed:            true,
 								MarkdownDescription: "Path style access for S3 requests. If the underlying S3 supports both, we recommend to not set path_style_access.",
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"push_s3_delete_disabled": schema.BoolAttribute{
 								Optional:            true,
 								Computed:            true,
 								MarkdownDescription: "Controls whether the `s3.delete-enabled=false` flag is sent to clients.",
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"remote_signing_url_style": schema.StringAttribute{
 								Optional: true,
@@ -193,6 +225,9 @@ func (r *lakekeeperWarehouseResource) Schema(ctx context.Context, req resource.S
 									),
 								},
 								MarkdownDescription: fmt.Sprintf("S3 URL style detection mode for remote signing. One of `%s`, `%s`, `%s`. Default: `%s`.", profile.AutoSigningURLStyle, profile.PathSigningURLStyle, profile.VirtualHostSigningURLStyle, profile.AutoSigningURLStyle),
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							}, "sts_role_arn": schema.StringAttribute{
 								Optional: true,
 							},
@@ -203,6 +238,9 @@ func (r *lakekeeperWarehouseResource) Schema(ctx context.Context, req resource.S
 									int64validator.AtLeast(0),
 								},
 								MarkdownDescription: "The validity of the STS tokens in seconds. Default is `3600`.",
+								PlanModifiers: []planmodifier.Int64{
+									int64planmodifier.UseStateForUnknown(),
+								},
 							},
 							"credential": schema.SingleNestedAttribute{
 								Required:            true,
@@ -289,16 +327,25 @@ func (r *lakekeeperWarehouseResource) Schema(ctx context.Context, req resource.S
 								Optional:            true,
 								Computed:            true,
 								MarkdownDescription: "Allow alternative protocols such as wasbs:// in locations. This is disabled by default. We do not recommend to use this setting except for migration.",
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"authority_host": schema.StringAttribute{
 								Optional:            true,
 								Computed:            true,
 								MarkdownDescription: "The authority host to use for authentication. Defaults to `https://login.microsoftonline.com`.",
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"host": schema.StringAttribute{
 								Optional:            true,
 								Computed:            true,
 								MarkdownDescription: "The host to use for the storage account. Defaults to `dfs.core.windows.net`.",
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"key_prefix": schema.StringAttribute{
 								Optional:            true,
@@ -310,6 +357,9 @@ func (r *lakekeeperWarehouseResource) Schema(ctx context.Context, req resource.S
 								MarkdownDescription: "The validity of the sas token in seconds. Default is `3600`.",
 								Validators: []validator.Int64{
 									int64validator.AtLeast(0),
+								},
+								PlanModifiers: []planmodifier.Int64{
+									int64planmodifier.UseStateForUnknown(),
 								},
 							},
 							"credential": schema.SingleNestedAttribute{

--- a/internal/provider/resource_warehouse_role_assignment.go
+++ b/internal/provider/resource_warehouse_role_assignment.go
@@ -61,6 +61,9 @@ func (r *lakekeeperWarehouseRoleAssignmentResource) Schema(ctx context.Context, 
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The internal ID of this resource. In the form: `{{warehouse_id}}/{{role_id}}`",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"warehouse_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the warehouse.",

--- a/internal/provider/resource_warehouse_user_assignment.go
+++ b/internal/provider/resource_warehouse_user_assignment.go
@@ -61,6 +61,9 @@ func (r *lakekeeperWarehouseUserAssignmentResource) Schema(ctx context.Context, 
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The internal ID of this resource. In the form: `{{warehouse_id}}/{{user_id}}`",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"warehouse_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the warehouse.",

--- a/internal/provider/sdk/delete_profile.go
+++ b/internal/provider/sdk/delete_profile.go
@@ -10,8 +10,10 @@ import (
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -49,10 +51,16 @@ func DeleteProfileResourceSchema() rschema.SingleNestedAttribute {
 				},
 				Default:             stringdefault.StaticString("hard"),
 				MarkdownDescription: fmt.Sprintf("Type of the delete profile. Can be `%s` or `%s`. Default: `%s`", profile.HardDeleteProfileType, profile.SoftDeleteProfileType, profile.HardDeleteProfileType),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"expiration_seconds": rschema.Int32Attribute{
 				Optional:            true,
 				MarkdownDescription: "When the types is `soft`. Entity will be deleted after `expiration_seconds`. Default is `3600`",
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Validators: []validator.Object{deleteProfileValidator{}},


### PR DESCRIPTION
## Related Issue

No related issue

## Description

When running a plan and making a minor change, lots of computed attributes (e.g id, warehouse_id) are displayed as `(known after apply)` when they are core immutable elements. This MR adds PlanModifiers to those attributes so that they're read from the state instead.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Changes to Security Controls

None
