### PR TITLE
fix: Add some input validation to role/warehouse IDs

### DIFF
--- a/internal/provider/resource_project_role_assignment.go
+++ b/internal/provider/resource_project_role_assignment.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -74,6 +75,9 @@ func (r *lakekeeperProjectRoleAssignmentResource) Schema(ctx context.Context, re
 				MarkdownDescription: "The ID of the role.",
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^[^/]+$"), "must be a role UUID and NOT include the project UUID"),
+				},
 			},
 			"assignments": schema.SetAttribute{
 				ElementType: types.StringType,

--- a/internal/provider/resource_project_role_assignment_test.go
+++ b/internal/provider/resource_project_role_assignment_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -93,6 +94,17 @@ func TestAccLakekeeperProjectRoleAssignment_basic(t *testing.T) {
 				ResourceName:      "lakekeeper_project_role_assignment.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Check some basic attribute validation
+			{
+				Config: fmt.Sprintf(`				
+					resource "lakekeeper_project_role_assignment" "test" {
+						project_id = "%s"
+						role_id = "%s/%s"
+						assignments = ["describe"]
+					}
+				`, project.ID, project.ID, role.ID),
+				ExpectError: regexp.MustCompile("Attribute role_id must be a role UUID and NOT include the project UUID"),
 			},
 			// delete all assignments
 			{

--- a/internal/provider/resource_role_role_assignment.go
+++ b/internal/provider/resource_role_role_assignment.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -69,11 +70,17 @@ func (r *lakekeeperRoleRoleAssignmentResource) Schema(ctx context.Context, req r
 				MarkdownDescription: "The ID of the role.",
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^[^/]+$"), "must be a role UUID and NOT include the project UUID"),
+				},
 			},
 			"assignee_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the role to assign to the role.",
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^[^/]+$"), "must be a role UUID and NOT include the project UUID"),
+				},
 			},
 			"assignments": schema.SetAttribute{
 				ElementType:         types.StringType,

--- a/internal/provider/resource_role_role_assignment_test.go
+++ b/internal/provider/resource_role_role_assignment_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -95,6 +96,27 @@ func TestAccLakekeeperRoleRoleAssignment_basic(t *testing.T) {
 				ResourceName:      "lakekeeper_role_role_assignment.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Check some basic attribute validation
+			{
+				Config: fmt.Sprintf(`				
+					resource "lakekeeper_role_role_assignment" "test" {
+						role_id = "%s/%s"
+						assignee_id = "%s"
+						assignments = ["ownership"]
+					}
+				`, project.ID, role.ID, assignee.ID),
+				ExpectError: regexp.MustCompile("Attribute role_id must be a role UUID and NOT include the project UUID"),
+			},
+			{
+				Config: fmt.Sprintf(`				
+					resource "lakekeeper_role_role_assignment" "test" {
+						role_id = "%s"
+						assignee_id = "%s/%s"
+						assignments = ["ownership"]
+					}
+				`, role.ID, project.ID, assignee.ID),
+				ExpectError: regexp.MustCompile("Attribute assignee_id must be a role UUID and NOT include the project UUID"),
 			},
 			// delete all assignments
 			{

--- a/internal/provider/resource_role_user_assignment.go
+++ b/internal/provider/resource_role_user_assignment.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -69,6 +70,9 @@ func (r *lakekeeperRoleUserAssignmentResource) Schema(ctx context.Context, req r
 				MarkdownDescription: "The ID of the role.",
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^[^/]+$"), "must be a role UUID and NOT include the project UUID"),
+				},
 			},
 			"user_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the user to assign to this role.",

--- a/internal/provider/resource_role_user_assignment_test.go
+++ b/internal/provider/resource_role_user_assignment_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -98,6 +99,17 @@ func TestAccLakekeeperRoleUserAssignment_basic(t *testing.T) {
 				ResourceName:      "lakekeeper_role_user_assignment.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Check some basic attribute validation
+			{
+				Config: fmt.Sprintf(`				
+					resource "lakekeeper_role_user_assignment" "test" {
+						role_id = "%s/%s"
+						user_id = "%s"
+						assignments = ["ownership"]
+					}
+				`, project.ID, role.ID, user.ID),
+				ExpectError: regexp.MustCompile("Attribute role_id must be a role UUID and NOT include the project UUID"),
 			},
 			// delete all assignments
 			{

--- a/internal/provider/resource_warehouse_role_assignment.go
+++ b/internal/provider/resource_warehouse_role_assignment.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -69,11 +70,17 @@ func (r *lakekeeperWarehouseRoleAssignmentResource) Schema(ctx context.Context, 
 				MarkdownDescription: "The ID of the warehouse.",
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^[^/]+$"), "must be a warehouse UUID and NOT include the project UUID"),
+				},
 			},
 			"role_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the role to assign to the warehouse.",
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^[^/]+$"), "must be a role UUID and NOT include the project UUID"),
+				},
 			},
 			"assignments": schema.SetAttribute{
 				ElementType: types.StringType,

--- a/internal/provider/resource_warehouse_role_assignment_test.go
+++ b/internal/provider/resource_warehouse_role_assignment_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"testing"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -99,6 +100,27 @@ func TestAccLakekeeperWarehouseRoleAssignment_basic(t *testing.T) {
 				ResourceName:      "lakekeeper_warehouse_role_assignment.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Check some basic attribute validation
+			{
+				Config: fmt.Sprintf(`
+					resource "lakekeeper_warehouse_role_assignment" "test" {
+						warehouse_id = "%s/%s"
+						role_id = "%s"
+						assignments = ["ownership"]
+					}
+				`, project.ID, warehouse.ID, role.ID),
+				ExpectError: regexp.MustCompile("Attribute warehouse_id must be a warehouse UUID and NOT include the project\nUUID"),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "lakekeeper_warehouse_role_assignment" "test" {
+						warehouse_id = "%s"
+						role_id = "%s/%s"
+						assignments = ["ownership"]
+					}
+				`, warehouse.ID, project.ID, role.ID),
+				ExpectError: regexp.MustCompile("Attribute role_id must be a role UUID and NOT include the project UUID"),
 			},
 			// delete all assignments
 			{

--- a/internal/provider/resource_warehouse_user_assignment.go
+++ b/internal/provider/resource_warehouse_user_assignment.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -69,6 +70,9 @@ func (r *lakekeeperWarehouseUserAssignmentResource) Schema(ctx context.Context, 
 				MarkdownDescription: "The ID of the warehouse.",
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^[^/]+$"), "must be a warehouse UUID and NOT include the project UUID"),
+				},
 			},
 			"user_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the user to assign to this warehouse.",

--- a/internal/provider/resource_warehouse_user_assignment_test.go
+++ b/internal/provider/resource_warehouse_user_assignment_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"testing"
 
 	permissionv1 "github.com/baptistegh/go-lakekeeper/pkg/apis/management/v1/permission"
@@ -100,6 +101,17 @@ func TestAccLakekeeperWarehouseUserAssignment_basic(t *testing.T) {
 				ResourceName:      "lakekeeper_warehouse_user_assignment.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Check some basic attribute validation
+			{
+				Config: fmt.Sprintf(`
+					resource "lakekeeper_warehouse_user_assignment" "test" {
+						warehouse_id = "%s/%s"
+						user_id = "%s"
+						assignments = ["ownership"]
+					}
+				`, project.ID, warehouse.ID, user.ID),
+				ExpectError: regexp.MustCompile("Attribute warehouse_id must be a warehouse UUID and NOT include the project\nUUID"),
 			},
 			// delete all assignments
 			{


### PR DESCRIPTION
## Related Issue

No Issue

## Description

When using the provider I made the mistake of using, for example, `lakekeeper_role.this.id` instead of `lakekeeper_role.this.role_id`, and the provider returned a generic error with no detail. This MR add some input validation to those attributes to avoid this mistake and ensure UUIDs in the correct format are passed in.

## Changes to Security Controls

None
