### PR TITLE
chore: do not comment on correct PR title

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -45,15 +45,6 @@ jobs:
               * `chore(deps): update dependencies`
 
               We only use types: `feat`, `fix`, `docs`, `chore`, `test` and `ci`.
-
-      - uses: marocchino/sticky-pull-request-comment@v2
-        if: ${{ steps.check.outputs.success == 'true'}}
-        with:
-          header: 'pr-title-checker'
-          recreate: true
-          message: |
-              ### ✅ PR Title Formatted Correctly
-              The title of this PR match the correct format. Thank you!
       
       - if: ${{ steps.check.outputs.success == 'false'}}
         name: Fail on invalid title


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to display lint check feedback only upon failures, removing success notifications from pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->