### PR TITLE
fix: omit client-injected defaults from ADLS storage profile

### DIFF
--- a/internal/provider/sdk/storage_profile.go
+++ b/internal/provider/sdk/storage_profile.go
@@ -264,6 +264,33 @@ func (m *ADLSStorageProfileModel) AsSDK() (profile.StorageSettings, error) {
 		opt...,
 	)
 
+	// NewADLSStorageSettings injects client-side defaults for several optional
+	// fields (host = "dfs.core.windows.net", authority_host =
+	// "https://login.microsoftonline.com", sas_token_validity_seconds = 3600).
+	// The Lakekeeper server, like the UI, expects these to be omitted unless
+	// explicitly set: it stores null and applies its own defaults at runtime.
+	// Sending the injected defaults instead breaks in field-specific ways:
+	//   - host: a non-empty host becomes CloudLocation::Custom, which reuses the
+	//     dfs URI for the blob service client and breaks the blob-only "Get User
+	//     Delegation Key" SAS minting (400 InvalidUri from the Windows-Azure-HDFS
+	//     endpoint) for azure_system_identity and client_credentials.
+	//   - authority_host: treated as immutable, so updating a warehouse stored
+	//     with null fails ("Field `authority_host` cannot be updated to prevent
+	//     loss of data").
+	//   - sas_token_validity_seconds: Optional+Computed stored as null, so a sent
+	//     3600 triggers a "provider produced inconsistent result" error.
+	// Mirror the UI and omit each value when the user has not set it explicitly,
+	// letting the server apply its defaults.
+	if m.Host.ValueString() == "" {
+		sp.Host = nil
+	}
+	if m.AuthorityHost.ValueString() == "" {
+		sp.AuthorityHost = nil
+	}
+	if m.SASTokenValiditySeconds.IsNull() || m.SASTokenValiditySeconds.IsUnknown() {
+		sp.SASTokenValiditySeconds = nil
+	}
+
 	return sp, nil
 }
 


### PR DESCRIPTION
## Related Issue

No related issue.

## Description

When migrating from `credential.client_credentials` to `credential.azure_system_identity`, various issues were encountered with the provider despite the same change working in the UI. Turns out, NewADLSStorageSettings` in go-lakekeeper injects client-side default values for three optional ADLS storage-profile fields that neither the Lakekeeper UI nor the server expect to be sent:

- `host` = `dfs.core.windows.net`
- `authority_host` = `https://login.microsoftonline.com`
- `sas_token_validity_seconds` = `3600`

The server stores these as null when omitted and applies its own defaults at runtime. Because the provider was passing the injected defaults through unchanged, warehouses using `azure_system_identity` (and `client_credentials`) failed in three distinct ways:

- **host**: a non-empty `host` causes the server to treat the location as `CloudLocation::Custom`, which reuses the `dfs` URI for the *blob* service client. That breaks the blob-only "Get User Delegation Key" call used to mint short-term SAS tokens, producing a `412 ShortTermCredentialError` / `400 InvalidUri` from the `Windows-Azure-HDFS` endpoint.
- **authority_host**: the server treats this field as immutable, so updating a warehouse whose stored value is null fails with "Field `authority_host` cannot be updated to prevent loss of data".
- **sas_token_validity_seconds**: this is `Optional`+`Computed` and stored as null when unset, so sending `3600` triggers a "provider produced inconsistent result after apply" error.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optional Azure Data Lake Storage settings are now omitted when not explicitly configured.
  * Prevents unintended default host, authority host, or SAS token validity values from being sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->