### PR TITLE
fix: allow different idp providers when creating users

### DIFF
--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -55,8 +55,8 @@ func (r *lakekeeperUserResource) Schema(ctx context.Context, req resource.Schema
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
-						regexp.MustCompile("^(oidc|kubernetes)~"),
-						"The id must be prefixed with `<idp-identifier>~`. `<idp-identifier>` can be `oidc` or `kubernetes`.",
+						regexp.MustCompile("^[^~]+~.+"),
+						"The id must be in the format `<idp-identifier>~<id>`, for example `oidc~1234567890`.",
 					),
 				},
 			},


### PR DESCRIPTION
…user

## Related Issue

No issue

## Description

Lakekeeper supports multiple OIDC providers ([docs](https://docs.lakekeeper.io/docs/0.13.x/authentication/#multiple-oidc-providers)) and users created using these providers have IDs with different IDPs. For example, an OIDC provider configured as `LAKEKEEPER__OPENID_PROVIDERS__OKTA__...` would create users with `okta~<user-id>` as their ID.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded accepted user ID formats to support any non-empty identity provider prefix and identifier.
  * Updated validation guidance to reflect the broader supported format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->