### PR TITLE
fix(warehouse): persist ID to state immediately after create (avoid orphan on post-create failure)

### DIFF
--- a/internal/provider/resource_warehouse.go
+++ b/internal/provider/resource_warehouse.go
@@ -504,6 +504,22 @@ func (r *lakekeeperWarehouseResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
+	// The warehouse now EXISTS server-side. Persist its identity to state
+	// immediately, before the post-create steps below (protection, activation,
+	// managed access, read-back). If any of those fail and we returned without
+	// having saved state, Terraform would consider the warehouse never-created
+	// and try to create it again on the next apply — which fails with
+	// CreateWarehouseStorageProfileOverlap and leaves the resource permanently
+	// orphaned (created in Lakekeeper, absent from state). Recording the ID here
+	// makes such a failure recoverable: the next apply updates/reads the existing
+	// warehouse instead of re-creating it.
+	state.ID = types.StringValue(state.ProjectID.ValueString() + "/" + w.ID)
+	state.WarehouseID = types.StringValue(w.ID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// set protection
 	if state.Protected.ValueBool() {
 		_, _, err := r.client.WarehouseV1(state.ProjectID.ValueString()).SetWarehouseProtection(ctx, w.ID, &managementv1.SetProtectionOptions{Protected: state.Protected.ValueBool()})


### PR DESCRIPTION
## Problem

`lakekeeperWarehouseResource.Create` creates the warehouse server-side, then performs several post-create calls — `SetWarehouseProtection`, `Deactivate`, `Get`, `SetManagedAccess`, `RefreshFromSettings` — and **each error path `return`s without ever calling `resp.State.Set`**. `resp.State.Set(ctx, &state)` only runs at the very end.

So if any post-create step fails, Terraform records the warehouse as **never created**, even though it now exists in Lakekeeper. The next `apply` tries to create it again and fails with:

```
code=400 message=Storage profile overlaps with existing warehouse <name>
type=CreateWarehouseStorageProfileOverlap
```

The resource is then **permanently orphaned** — present in Lakekeeper, absent from state, and every subsequent reconcile re-collides. The only escape is a manual API delete of the warehouse.

## Repro (observed in a real deployment)

A warehouse resource with `managed_access` set, applied via a Crossplane `provider-opentofu` Workspace against Lakekeeper v0.13.x:
1. `Create` succeeds → warehouse exists server-side.
2. A post-create step errors → handler returns **before** `resp.State.Set`.
3. State contains the parent project but **not** the warehouse.
4. Next reconcile → `Create` again → `CreateWarehouseStorageProfileOverlap` → abort.
5. Loop forever; state never advances past the project.

Confirmed live: warehouse present in Lakekeeper across reconciles, state serial incrementing, but warehouse never in state.

## Fix

Persist the resource identity (`id`, `warehouse_id`) via `resp.State.Set` **immediately after the successful `Create`**, before the post-create steps. A later failure then leaves Terraform tracking the resource, so the next apply updates/reads the existing warehouse instead of re-creating it.

Minimal, surgical change in `Create`; the terminal `resp.State.Set` still runs with the fully-refreshed state on the happy path.

## Verification

`go build ./...`, `gofmt -l`, `go vet ./internal/provider/` all clean. Opening as **draft** — happy to add an acceptance test that asserts state retains the warehouse ID when a post-create step fails (e.g. injecting a managed-access error), and to adjust per maintainer preference (an alternative is wrapping post-create failures so they don't discard state, but persisting-early is the least invasive).

Fixes the orphan/overlap loop for anyone managing warehouses declaratively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warehouse creation reliability by saving the warehouse identity immediately after creation.
  * Prevented follow-up configuration steps from proceeding when the new warehouse cannot be saved to state.
  * Reduced the risk of Terraform treating successfully created warehouses as if they were never created after later failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->